### PR TITLE
feat: Add newline after each file in JSON output

### DIFF
--- a/json.xsl
+++ b/json.xsl
@@ -26,10 +26,11 @@
   "done": true,
   "files": [
     <xsl:for-each select="descendant::resource[license-approval/@name='false']">
-      <xsl:text>  "</xsl:text>
+      <xsl:if test="position() != 1"><xsl:text>    </xsl:text></xsl:if>
+      <xsl:text>"</xsl:text>
       <xsl:value-of select="@name"/>
       <xsl:text>"</xsl:text>
-      <xsl:if test="position() != last()"><xsl:text>,</xsl:text></xsl:if>
+      <xsl:if test="position() != last()"><xsl:text>,&#xA;</xsl:text></xsl:if>
     </xsl:for-each>
   ]
 }


### PR DESCRIPTION
I'm a little bit worried this might impact the indentation, but the idea is to get each affected file written out on its own line in the `files` array, rather than being a single long line with a bunch of filenames