### PR TITLE
feat!: bump Apache Creadur RAT 0.17

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,10 +67,7 @@ runs:
           --output-style "${{ github.action_path }}/json.xsl" \
           --input-exclude-file .ratignore \
           --log-level OFF \
-          -- "${{ github.workspace }}" \
-        | sed '/^INFO: Apache Creadur RAT/d' \
-        > .ratresults.json
-      continue-on-error: true
+          -- "${{ github.workspace }}"
 
     - name: Run Apache Creadur RAT without ratignore
       if: ${{ hashFiles('.ratignore') == '' }}
@@ -79,13 +76,4 @@ runs:
         java -jar "${{ github.action_path }}/apache-rat-${{ inputs.rat-version }}/apache-rat-${{ inputs.rat-version }}.jar" \
           --output-style "${{ github.action_path }}/json.xsl" \
           --log-level OFF \
-          -- "${{ github.workspace }}" \
-        | sed '/^INFO: Apache Creadur RAT/d' \
-        > .ratresults.json
-      continue-on-error: true
-
-    - name: Display & Test Results
-      shell: bash
-      run: |
-        cat .ratresults.json
-        jq -e '.unapproved == 0' .ratresults.json > /dev/null
+          -- "${{ github.workspace }}"

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
       See Apache dlcdn or archives for available versions.
       e.g. 0.15, 0.14, ...
     required: false
-    default: 0.16.1
+    default: 0.17
 
 runs:
   using: composite
@@ -62,12 +62,25 @@ runs:
     - name: Run Apache Creadur RAT with ratignore
       if: ${{ hashFiles('.ratignore') != '' }}
       shell: bash
-      run: java -jar "${{ github.action_path }}/apache-rat-${{ inputs.rat-version }}/apache-rat-${{ inputs.rat-version }}.jar" -s "${{ github.action_path }}/json.xsl" -E ".ratignore" -d "${{ github.workspace }}" > .ratresults.json
+      run: |
+        java -jar "${{ github.action_path }}/apache-rat-${{ inputs.rat-version }}/apache-rat-${{ inputs.rat-version }}.jar" \
+          --output-style "${{ github.action_path }}/json.xsl" \
+          --input-exclude-file .ratignore \
+          --log-level OFF \
+          -- "${{ github.workspace }}" \
+        | sed '/^INFO: Apache Creadur RAT/d' \
+        > .ratresults.json
 
     - name: Run Apache Creadur RAT without ratignore
       if: ${{ hashFiles('.ratignore') == '' }}
       shell: bash
-      run: java -jar "${{ github.action_path }}/apache-rat-${{ inputs.rat-version }}/apache-rat-${{ inputs.rat-version }}.jar" -s "${{ github.action_path }}/json.xsl" -d "${{ github.workspace }}" > .ratresults.json
+      run: |
+        java -jar "${{ github.action_path }}/apache-rat-${{ inputs.rat-version }}/apache-rat-${{ inputs.rat-version }}.jar" \
+          --output-style "${{ github.action_path }}/json.xsl" \
+          --log-level OFF \
+          -- "${{ github.workspace }}" \
+        | sed '/^INFO: Apache Creadur RAT/d' \
+        > .ratresults.json
 
     - name: Display & Test Results
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,7 @@ runs:
           -- "${{ github.workspace }}" \
         | sed '/^INFO: Apache Creadur RAT/d' \
         > .ratresults.json
+      continue-on-error: true
 
     - name: Run Apache Creadur RAT without ratignore
       if: ${{ hashFiles('.ratignore') == '' }}
@@ -81,6 +82,7 @@ runs:
           -- "${{ github.workspace }}" \
         | sed '/^INFO: Apache Creadur RAT/d' \
         > .ratresults.json
+      continue-on-error: true
 
     - name: Display & Test Results
       shell: bash

--- a/json.xsl
+++ b/json.xsl
@@ -21,11 +21,11 @@
   <xsl:output method="text"/>
   <xsl:template match="/">
 {
-  "unknown": <xsl:value-of select="count(descendant::header-type[attribute::name='?????'])"/>,
-  "unapproved": <xsl:value-of select="count(descendant::resource[license-approval/@name='false'])"/>,
+  "unknown": <xsl:value-of select="count(descendant::resource[license[@approval='false'] and license[@name='Unknown license']])"/>,
+  "unapproved": <xsl:value-of select="count(descendant::resource[license[@approval='false']])"/>,
   "done": true,
   "files": [
-    <xsl:for-each select="descendant::resource[license-approval/@name='false']">
+    <xsl:for-each select="descendant::resource[license[@approval='false']]">
       <xsl:if test="position() != 1"><xsl:text>    </xsl:text></xsl:if>
       <xsl:text>"</xsl:text>
       <xsl:value-of select="@name"/>


### PR DESCRIPTION
- Updated the default to: 0.17
- Updated the output style: `json.xsl`
- Updated the `rat` usage command.

  ```bash
  java -jar "${{ github.action_path }}/apache-rat-${{ inputs.rat-version }}/apache-rat-${{ inputs.rat-version }}.jar" \
            --output-style "${{ github.action_path }}/json.xsl" \
            --input-exclude-file .ratignore \
            --log-level OFF \
            -- "${{ github.workspace }}"
  ```
  
  - Changed `-s` to `--output-style`
  - Changed `-E` to `--input-exclude-file`
  - Added `--log-level` to try and silence any additional printouts.
  - Removed `-d` flag, used new pattern `--`
  - Removed `Display & Test Results` step.
    - Rat now throws the following exception when there is an unapproved issue. It appears we no longer need to create and evaluate the JSON file to decide if the action should throw an error/fail.
      ```
      Exception in thread "main" org.apache.rat.document.RatDocumentAnalysisException: Issues with UNAPPROVED
          at org.apache.rat.Report.main(Report.java:53)
      ```
      
      Will keep the `output-style` of `json.xsl` to generate a condensed printout, in JSON, of only the files that were unapproved.
    
      Example JSON printout:
  
      ```json
      {
        "unknown": 0,
        "unapproved": 0,
        "done": true,
        "files": [
      
        ]
      }
      ```