### PR TITLE
ci: add workflow to test own action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Test Action
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test-without-ratignore:
+    name: Test without .ratignore
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Case 1 - All Has License
+        uses: ./
+
+      - name: Create missing header license files
+        run: |
+          echo "random string" > file-missing-license.txt
+
+      - name: Use Case 2 - File Missing License
+        id: rat-failed-case
+        continue-on-error: true
+        uses: ./
+
+      - name: Verify Expected Fail Case
+        run: |
+          if [ "${{ steps.rat-failed-case.outcome }}" != "failure" ]; then
+            echo "Expected Failure but Passed"
+            exit 1
+          else
+            echo "Correctly Failed"
+          fi
+
+  test-with-ratignore:
+    name: Test with .ratignore
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create .ratignore file
+        # Creating a .ratignore file and ignoring itself & file-missing-license.txt.
+        run: echo -e ".ratignore\nfile-missing-license.txt" > .ratignore
+
+      - name: Create missing header license files
+        run: |
+          echo "random string" > file-missing-license.txt
+
+      - name: Testing Apache Creadur RAT Action (self-test)
+        uses: ./


### PR DESCRIPTION
Add a GitHub Action workflow to test itself

Example run: https://github.com/erisu/apache-rat-action/actions/runs/19169653238

This workflow tests the following use cases:

- Without `.ratignore`
  - Passes when all files have an ASF license header.
  - Fails when one or more files are missing the ASF license header.
- With `.ratignore`
  - Passes when all files have an ASF license header, excluding the files listed in `.ratignore`.
  
---

> [!NOTE]
> In the above **example run**, you will see an **annotation** showing an error from the “test without `.ratignore`” use case, which exits with code `1`. This is expected because we are testing the scenario where a file is missing the license header, which correctly triggers an error. The workflow is configured to ignore errors during this test, and we later verify that the error was thrown and report the test as successful.