### PR TITLE
feat!: bump Apache RAT 0.18 & JDK 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# eclipse-temurin:21.0.10_7-jdk
-FROM eclipse-temurin@sha256:e58e492628c1428ceb838afc1a1b8762673d5eaa09296f560c363daea0fdcf3b
+# eclipse-temurin:25.0.3_9-jdk
+FROM eclipse-temurin@sha256:c3a5cfd77c9a43dd95269a266290d365b79b174381d8336a3f76a7ae117beefa
 
 # Install dependecies
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
     name: Check License Headers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: erisu/apache-rat-action@v2
 ```
 
@@ -62,7 +62,7 @@ To override the version, add the `rat-version` setting to the `with` block when 
 ```yml
 - uses: erisu/apache-rat-action@v2
   with:
-    rat-version: '0.17'
+    rat-version: '0.18'
 ```
 
 ## Testing Locally
@@ -83,7 +83,7 @@ This action can be tested locally by building the Docker image and running it ag
   ```bash
   docker run --rm \
     -e GITHUB_WORKSPACE=/workspace \
-    -e INPUT_RAT_VERSION=0.17 \
+    -e INPUT_RAT_VERSION=0.18 \
     -v "$(pwd):/workspace" \
     apache-rat-action
   ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This action can be tested locally by building the Docker image and running it ag
   docker run --rm \
     -e GITHUB_WORKSPACE=/workspace \
     -e INPUT_RAT_VERSION=0.18 \
-    -v "$(pwd):/workspace" \
+    -v "$(pwd):/workspace:ro" \
     apache-rat-action
   ```
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
       See Apache dlcdn or archives for available versions.
       e.g. 0.15, 0.14, ...
     required: false
-    default: 0.17
+    default: 0.18
 
 runs:
   using: docker


### PR DESCRIPTION
- Bump Apache RAT to 0.18
- Update JDK to `eclipse-temurin@sha256:c3a5cfd77c9a43dd95269a266290d365b79b174381d8336a3f76a7ae117beefa`
  - Pinned version of `eclipse-temurin:25.0.3_9-jdk`