### PR TITLE
feat: ensure copied files ownership is app:app & improve README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN groupadd --system app \
 WORKDIR /app
 
 RUN chown -R app:app /app
-COPY verify-header-licenses json.xsl ./
+COPY --chown=app:app verify-header-licenses json.xsl ./
 
 # Make script executable
 RUN chmod +x /app/verify-header-licenses

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ This action can be tested locally by building the Docker image and running it ag
 5. Run the image:
 
   ```bash
-  docker run --rm \
+  docker run --rm -t \
+    --cap-drop=ALL \
+    --security-opt=no-new-privileges \
     -e GITHUB_WORKSPACE=/workspace \
     -e INPUT_RAT_VERSION=0.18 \
     -v "$(pwd):/workspace:ro" \

--- a/verify-header-licenses
+++ b/verify-header-licenses
@@ -166,7 +166,7 @@ if [[ -n "${RAT_EXCLUDE_PATH:-}" ]]; then
   info "RAT exclude file was configured and will be used."
   RAT_ARGS+=( --input-exclude-file "$RAT_EXCLUDE_PATH" )
 else
-  info "NO RAT exclude file was configured."
+  warn "NO RAT exclude file was configured."
 fi
 
 # MARK: Running RAT


### PR DESCRIPTION
- Ensure that the copied files to /app has ownership of app:app
- Improved the READAME step in how to run locally for testing
  - Added `cap-drop=ALL` to remove Linux capabilities
  - Added `security-opt=no-new-privileges` to prevent other forms of privilege escalation or extra capabilities
  - Added `-t` flag to allocate a pseudo-tty
- Convert "NO RAT exclude file was configured" message to display as a warn